### PR TITLE
add-dvadeset-jedan

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -207,6 +207,8 @@
     "numeric": 70,
     "latitude": 44,
     "longitude": 18
+    "name": "Dvadeset Jedan",
+    "link": "https://t.me/dvadesetjedan21"
   },
   {
     "country": "Botswana",
@@ -423,6 +425,8 @@
     "numeric": 191,
     "latitude": 45.1667,
     "longitude": 15.5
+    "name": "Dvadeset Jedan",
+    "link": "https://t.me/dvadesetjedan21"
   },
   {
     "country": "Cuba",
@@ -1025,6 +1029,9 @@
     "numeric": 807,
     "latitude": 41.8333,
     "longitude": 22
+    "name": "Dvadeset Jedan",
+    "link": "https://t.me/dvadesetjedan21"
+
   },
   {
     "country": "Madagascar",
@@ -1161,6 +1168,8 @@
     "numeric": 499,
     "latitude": 42,
     "longitude": 19
+    "name": "Dvadeset Jedan",
+    "link": "https://t.me/dvadesetjedan21"
   },
   {
     "country": "Montserrat",
@@ -1537,6 +1546,8 @@
     "numeric": 688,
     "latitude": 44,
     "longitude": 21
+    "name": "Dvadeset Jedan",
+    "link": "https://t.me/dvadesetjedan21"
   },
   {
     "country": "Seychelles",
@@ -1577,6 +1588,9 @@
     "numeric": 705,
     "latitude": 46,
     "longitude": 15
+    "name": "Dvadeset Jedan",
+    "link": "https://t.me/dvadesetjedan21"
+
   },
   {
     "country": "Solomon Islands",


### PR DESCRIPTION
Adding Dvadeset Jedan a community for:
- Serbia
- Slovenia
- Croatia
- Bosnia and Hercegovina
- Montenegro
- Macedonia

For now people from these former Yugoslav republic joined and use the group, but I estimate soon, that there will be multiple sub-communities in each country under Dvadeset Jedan umbrella, for easier local networking and meetups, etc.