### PR TITLE
Add Bitcoin Paraguay community 🇵🇾

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -1384,7 +1384,9 @@
     "alpha3": "PRY",
     "numeric": 600,
     "latitude": -23,
-    "longitude": -58
+    "longitude": -58,
+    "name": "Bitcoin Paraguay",
+    "link_to_public_community_group": "https://bitcoinparaguay.org/"
   },
   {
     "country": "Peru",


### PR DESCRIPTION
Add Bitcoin Paraguay community page ( https://bitcoinparaguay.org/ ).