### PR TITLE
added La Crypta 🇦🇷

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -70,7 +70,9 @@
     "alpha3": "ARG",
     "numeric": 32,
     "latitude": -34,
-    "longitude": -64
+    "longitude": -64,
+    "name": "La Crypta",
+    "link_to_public_community_group": "https://lacrypta.ar/"
   },
   {
     "country": "Armenia",


### PR DESCRIPTION
La Crypta is the biggest Bitcoin ONLY community in Argentina. Started by 2013 bitcoiners we developed more than 80 open source repositories, podcasts, have the largest discord in the ecosystem, participate in Hackatons and multiple conferences with panels and keynotes.

https://discord.gg/lacryptaok